### PR TITLE
fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
     RUSTFLAGS: -Dwarnings

--- a/nsm-io/src/lib.rs
+++ b/nsm-io/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![allow(clippy::upper_case_acronyms)]
 //! NitroSecurityModule IO
 //! # Overview
 //! This module contains the structure definitions that allows data interchange between


### PR DESCRIPTION
Move the raw pointer handling functions to nsm-lib and allow functions in the
nsm-lib to be unsafe without documentation, since they're exposing a native
library.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
