### PR TITLE
Fix missing enums from cbindgen generated header

### DIFF
--- a/nsm-lib/Cargo.toml
+++ b/nsm-lib/Cargo.toml
@@ -10,7 +10,7 @@ aws-nitro-enclaves-nsm-api = { path = "../" }
 serde_bytes = "0.11"
 
 [build-dependencies]
-cbindgen = { version = "0.15", default-features = false }
+cbindgen = { version = "0.21", default-features = false }
 
 [lib]
 name = "nsm"

--- a/nsm-lib/cbindgen.toml
+++ b/nsm-lib/cbindgen.toml
@@ -12,7 +12,7 @@ include_guard = "NSM_LIB_H"
 
 [parse]
 parse_deps = true
-include = ["nsm-io"]
+include = ["aws-nitro-enclaves-nsm-api"]
 
 [enum]
 rename_variants = "QualifiedScreamingSnakeCase"

--- a/nsm-lib/src/lib.rs
+++ b/nsm-lib/src/lib.rs
@@ -8,7 +8,8 @@
 //! This module implements wrappers over the NSM Rust API which enable
 //! access to the API for non-Rust callers (ex.: C/C++ etc.).
 
-use aws_nitro_enclaves_nsm_api::api::{Digest, ErrorCode, Request, Response};
+pub use aws_nitro_enclaves_nsm_api::api::{Digest, ErrorCode};
+use aws_nitro_enclaves_nsm_api::api::{Request, Response};
 use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
 use serde_bytes::ByteBuf;
 use std::ptr::copy_nonoverlapping;


### PR DESCRIPTION
Fix missing enums from cbindgen generated header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
