### PR TITLE
CI: Fix failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,17 @@ jobs:
         strategy:
             matrix:
                 rust: [1.46.0, stable, nightly]
+                include:
+                  - rust: 1.46.0
+                    disable_lints: "-A derive_partial_eq_without_eq"
+
         steps:
         - uses: actions/checkout@v2
         - uses: dtolnay/rust-toolchain@master
           with:
               toolchain: ${{matrix.rust}}
+              if: ${{matrix.disable_lints}}
+              args: ${{matrix.disable_lints}}
         - run: cargo test --all
 
     clippy:


### PR DESCRIPTION
This change suppresses clippy (nightly) error for
derive_partial_eq_without_eq lint.

Signed-off-by: Erdem Meydanli <meydanli@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
