### PR TITLE
Introduce default enabled nix feature flag to allow for non nix usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,3 @@ serde_cbor = "0.11"
 
 [features]
 default = ["nix"]
-nix = ["dep:nix"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,13 @@ default-members = [ "." ]
 lto = true
 
 [dependencies]
-nix = "0.20"
+nix = { version = "0.20", optional = true }
 libc = "0.2"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"
+
+[features]
+default = ["nix"]
+nix = ["dep:nix"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@
 //! nsm_driver provides the ioctl interface for the Nitro Secure Module driver.
 
 pub mod api;
+#[cfg(feature = "nix")]
 pub mod driver;


### PR DESCRIPTION
*Issue #, if available:* [40](https://github.com/aws/aws-nitro-enclaves-nsm-api/issues/40)

*Description of changes:* Update nix dependency to be optional, with the feature default enabled. This will allow non *nix systems to use this crate for its type definitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
