### PR TITLE
update nix to 0.26 and fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = [ "." ]
 lto = true
 
 [dependencies]
-nix = { version = "0.20", optional = true }
+nix = { version = "0.26", optional = true }
 libc = "0.2"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
*Issue #, if available:*

No issue number.

*Description of changes:*

- Updated nix dependency to "0.26" in Cargo.toml
- Removed use of deprecated `nix::sys::uio::IoVec` in favor of `std::io::IoSlice` and `std::io::IoSliceMut`. These replacements are the ones suggested in the [nix documentation](https://docs.rs/nix/latest/nix/sys/uio/struct.IoVec.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.