### PR TITLE
driver: wrap fd returned from nsm_init in Option

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -109,19 +109,19 @@ pub fn nsm_process_request(fd: i32, request: Request) -> Response {
 }
 
 /// NSM library initialization function.  
-/// *Returns*: A descriptor for the opened device file.
-pub fn nsm_init() -> i32 {
+/// *Returns*: A descriptor for the opened device file, if successful.
+pub fn nsm_init() -> Option<i32> {
     let mut open_options = OpenOptions::new();
     let open_dev = open_options.read(true).write(true).open(DEV_FILE);
 
     match open_dev {
         Ok(open_dev) => {
             debug!("Device file '{}' opened successfully.", DEV_FILE);
-            open_dev.into_raw_fd()
+            Some(open_dev.into_raw_fd())
         }
         Err(e) => {
             error!("Device file '{}' failed to open: {}", DEV_FILE, e);
-            -1
+            None
         }
     }
 }


### PR DESCRIPTION
Returning an Option instead of the raw file descriptor makes it easier for the caller to ensure that the file was opened successfully. It also forces them to handle any errors instead of allowing them to assume that it was successful, only to be met with "InternalError" when nsm_process_request is later used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
