### PR TITLE
Add ABI compatibile version naming, update to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1
+* Bump nix dependency to 0.31
+* Add ABI compatibility version naming to libnsm soname install process
+
 # 0.5.0
 Changes:
 * Bump version to 1.92

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-nsm-api"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 rust-version = "1.92"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ VERSION = $(shell grep "version" Cargo.toml | head -n 1 | cut -d' ' -f3 | tr -d 
 RELEASE_DIR	= target/release
 RUSTC_STATIC_LIBS = $(shell cargo rustc -q -- --print=native-static-libs)
 
+LIBNSM_ABI_VERSION = 0
+LIBNSM_SONAME = libnsm.so
+LIBNSM_SONAME_ABI_VERSION = $(LIBNSM_SONAME).$(LIBNSM_ABI_VERSION)
+LIBNSM_SONAME_VERSION = $(LIBNSM_SONAME).$(VERSION)
+
 ifeq ($(PREFIX),)
 	PREFIX := /usr/local
 endif
@@ -115,8 +120,9 @@ install: nsm-lib libnsm.pc
 	install -d $(DESTDIR)$(INCLUDEDIR)
 	install -m 644 $(RELEASE_DIR)/nsm.h $(DESTDIR)$(INCLUDEDIR)
 	install -m 644 libnsm.pc $(DESTDIR)$(LIBDIR)/pkgconfig
-	install -m 755 $(RELEASE_DIR)/libnsm.so $(DESTDIR)$(LIBDIR)
+	patchelf --set-soname $(LIBNSM_SONAME_ABI_VERSION) $(RELEASE_DIR)/$(LIBNSM_SONAME)
+	install -m 755 $(RELEASE_DIR)/$(LIBNSM_SONAME) $(DESTDIR)$(LIBDIR)/$(LIBNSM_SONAME_VERSION)
 	install -m 644 $(RELEASE_DIR)/libnsm.a $(DESTDIR)$(LIBDIR)
-
+	cd $(DESTDIR)$(LIBDIR)/ ; ln -sf $(LIBNSM_SONAME_VERSION) $(LIBNSM_SONAME_ABI_VERSION) ; ln -sf $(LIBNSM_SONAME_ABI_VERSION) $(LIBNSM_SONAME)
 clean:
 	cargo clean

--- a/nsm-lib/Cargo.toml
+++ b/nsm-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsm-lib"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/nsm-test/Cargo.toml
+++ b/nsm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsm-test"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Follow libtool's versioning convention to provide some ABI stability.